### PR TITLE
Support Entry creation and rendering

### DIFF
--- a/flutter/lib/dashboard/view/dashboard_screen.dart
+++ b/flutter/lib/dashboard/view/dashboard_screen.dart
@@ -24,15 +24,27 @@ class DashboardScreen extends StatelessWidget {
                 return Text('UserID: $userId');
               },
             ),
-            EntriesList(),
             ElevatedButton(
               child: const Text('Logout'),
               onPressed: () {
                 context.read<UserBloc>().add(RemoveUser());
               },
             ),
+            Expanded(child: EntriesList()),
           ],
         ),
+      ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: () {
+          Navigator.push(
+            context,
+            MaterialPageRoute(builder: (context) {
+              return AddEntryScreen();
+            }),
+          );
+        },
+        child: Icon(Icons.add),
+        tooltip: "Add Entry",
       ),
     );
   }

--- a/flutter/lib/entries/blocs/entries_bloc.dart
+++ b/flutter/lib/entries/blocs/entries_bloc.dart
@@ -32,7 +32,14 @@ class EntriesBloc extends Bloc<EntriesEvent, EntriesState> {
       final entries = await entryRepository.getEntries();
       yield EntriesLoaded(entries);
     } catch (e) {
-      yield EntriesNotLoaded(e as Exception);
+      if (e is Exception) {
+        yield EntriesNotLoaded(e);
+      } else if (e is TypeError) {
+        yield EntriesNotLoaded(Exception(e.toString()));
+      } else {
+        yield EntriesNotLoaded(
+            Exception('Something went wrong while loading entries'));
+      }
     }
   }
 
@@ -62,7 +69,7 @@ class EntriesBloc extends Bloc<EntriesEvent, EntriesState> {
           .where((entry) => entry.id != event.entry.id)
           .toList();
       yield EntriesLoaded(updatedEntries);
-      await entryRepository.delete(event.entry);
+      await entryRepository.delete(event.entry.id);
     }
   }
 }

--- a/flutter/lib/entries/models/entry.dart
+++ b/flutter/lib/entries/models/entry.dart
@@ -47,12 +47,17 @@ class Entry extends Equatable {
   final DateTime dateTime;
   final Location location;
 
-  Entry(this.id, this.title, this.body, this.dateTime, this.location);
-
-  Entry.asNew(this.title, this.body, this.location,
-      {String? id, DateTime? dateTime})
+  Entry(
+      {String? id,
+      required String title,
+      required String body,
+      DateTime? dateTime,
+      required Location location})
       : id = id ?? Uuid().generateV4(),
-        dateTime = dateTime ?? DateTime.now();
+        title = title,
+        body = body,
+        dateTime = dateTime ?? DateTime.now(),
+        location = location;
 
   @override
   List<Object?> get props => [id, title, body, dateTime, location];

--- a/flutter/lib/entries/persistence/entry_dao.dart
+++ b/flutter/lib/entries/persistence/entry_dao.dart
@@ -25,11 +25,11 @@ class EntryDao extends Dao<Entry> {
   @override
   Entry fromMap(Map<String, dynamic> query) {
     return Entry(
-        query[columnId],
-        query[_columnTitle] as String,
-        query[_columnBody] as String,
-        DateTime.parse(query[_columnDateTime]),
-        _fromLocationMap(query[_columnLocation]));
+        id: query[columnId],
+        title: query[_columnTitle] as String,
+        body: query[_columnBody] as String,
+        dateTime: DateTime.parse(query[_columnDateTime]),
+        location: _fromLocationMap(query[_columnLocation]));
   }
 
   @override

--- a/flutter/lib/entries/persistence/entry_dao.dart
+++ b/flutter/lib/entries/persistence/entry_dao.dart
@@ -24,12 +24,13 @@ class EntryDao extends Dao<Entry> {
 
   @override
   Entry fromMap(Map<String, dynamic> query) {
+    print(query);
     return Entry(
         id: query[columnId],
         title: query[_columnTitle] as String,
         body: query[_columnBody] as String,
         dateTime: DateTime.parse(query[_columnDateTime]),
-        location: _fromLocationMap(query[_columnLocation]));
+        location: _fromLocationMap(jsonDecode(query[_columnLocation])));
   }
 
   @override
@@ -39,7 +40,7 @@ class EntryDao extends Dao<Entry> {
       _columnTitle: object.title,
       _columnBody: object.body,
       _columnDateTime: object.dateTime.toIso8601String(),
-      _columnLocation: _toLocationMap(object.location)
+      _columnLocation: jsonEncode(_toLocationMap(object.location))
     };
   }
 

--- a/flutter/lib/entries/persistence/entry_database_repository.dart
+++ b/flutter/lib/entries/persistence/entry_database_repository.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:journey/entries/entries.dart';
 import 'package:journey/persistence/dao.dart';
 import 'package:journey/persistence/database_provider.dart';
@@ -33,10 +35,9 @@ class EntryDatabaseRepository implements EntryRepository {
   }
 
   @override
-  Future<Entry> delete(Entry entry) async {
+  Future<void> delete(String entryId) async {
     final db = await _databaseProvider.db();
     await db.delete(_dao.tableName,
-        where: _dao.columnId + " = ?", whereArgs: [entry.id]);
-    return entry;
+        where: _dao.columnId + " = ?", whereArgs: [entryId]);
   }
 }

--- a/flutter/lib/entries/repositories/entry_repository.dart
+++ b/flutter/lib/entries/repositories/entry_repository.dart
@@ -5,7 +5,7 @@ abstract class EntryRepository {
 
   Future<Entry> update(Entry entry);
 
-  Future<Entry> delete(Entry entry);
+  Future<void> delete(String entryId);
 
   Future<List<Entry>> getEntries();
 }

--- a/flutter/lib/entries/view/add_entry_form/add_entry_form.dart
+++ b/flutter/lib/entries/view/add_entry_form/add_entry_form.dart
@@ -1,4 +1,6 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:journey/entries/entries.dart';
 
 class AddEntryForm extends StatefulWidget {
   @override
@@ -8,34 +10,70 @@ class AddEntryForm extends StatefulWidget {
 }
 
 class AddEntryFormState extends State<AddEntryForm> {
+  final _formKey = GlobalKey<FormState>();
+
+  final _titleController = TextEditingController();
+  final _bodyController = TextEditingController();
+
+  // Default to disabled since typing in one field validates the rest
+  AutovalidateMode _autovalidateMode = AutovalidateMode.disabled;
+
+  @override
+  void dispose() {
+    _titleController.dispose();
+    _bodyController.dispose();
+    super.dispose();
+  }
+
   @override
   Widget build(BuildContext context) {
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: <Widget>[
-        Padding(
-          padding: EdgeInsets.symmetric(horizontal: 8, vertical: 16),
-          child: TextField(
-            decoration: InputDecoration(
-              border: OutlineInputBorder(),
-              focusedBorder: OutlineInputBorder(),
-              labelText: "Title",
-              hintText: "Where did you go?",
+    return Form(
+      key: _formKey,
+      autovalidateMode: _autovalidateMode,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          TextFormField(
+            decoration: const InputDecoration(
+              labelText: 'Title *',
+              hintText: 'Where did you go?',
             ),
+            controller: _titleController,
+            validator: (value) {
+              if (value == null || value.isEmpty) {
+                return 'Please enter a title';
+              }
+              return null;
+            },
           ),
-        ),
-        Padding(
-          padding: EdgeInsets.symmetric(horizontal: 8, vertical: 16),
-          child: TextFormField(
-            decoration: InputDecoration(
-              border: OutlineInputBorder(),
-              focusedBorder: OutlineInputBorder(),
-              labelText: "Body",
-              hintText: "Tell us about your journey",
+          SizedBox(height: 16),
+          TextFormField(
+            decoration: const InputDecoration(
+              labelText: 'Body',
+              hintText: 'Tell us about your journey',
             ),
+            controller: _bodyController,
+            keyboardType: TextInputType.name,
           ),
-        ),
-      ],
+          SizedBox(height: 16),
+          ElevatedButton(
+            onPressed: () {
+              if (_formKey.currentState!.validate()) {
+                final entry = Entry(
+                    title: _titleController.text,
+                    body: _bodyController.text,
+                    location: Location('city', 'country', LatLng(1, 2)));
+                context.read<EntriesBloc>().add(AddEntry(entry));
+              } else {
+                setState(() {
+                  _autovalidateMode = AutovalidateMode.onUserInteraction;
+                });
+              }
+            },
+            child: const Text('Submit'),
+          ),
+        ],
+      ),
     );
   }
 }

--- a/flutter/lib/entries/view/add_entry_screen.dart
+++ b/flutter/lib/entries/view/add_entry_screen.dart
@@ -9,7 +9,7 @@ class AddEntryScreen extends StatelessWidget {
       appBar: AppBar(
         title: Text("Add Entry"),
       ),
-      body: AddEntryForm(),
+      body: Padding(padding: const EdgeInsets.all(16), child: AddEntryForm()),
     );
   }
 }

--- a/flutter/lib/entries/view/entries_list.dart
+++ b/flutter/lib/entries/view/entries_list.dart
@@ -9,12 +9,15 @@ class EntriesList extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return BlocBuilder<EntriesBloc, EntriesState>(builder: (_, state) {
+      print(state);
       if (state is EntriesLoading) {
         return this._buildLoading();
       } else if (state is EntriesLoaded) {
         return this._buildLoaded(state.entries);
+      } else if (state is EntriesNotLoaded) {
+        return this._buildErrorState(context, state.exception);
       } else {
-        return this._buildZeroState();
+        throw ArgumentError.value(state, 'Illegal entry state');
       }
     });
   }
@@ -29,7 +32,9 @@ class EntriesList extends StatelessWidget {
     if (entries.isEmpty) {
       return _buildZeroState();
     }
+    print(entries);
     return ListView.builder(
+      shrinkWrap: true,
       itemCount: entries.length,
       itemBuilder: (BuildContext context, int index) {
         final entry = entries[index];
@@ -42,11 +47,27 @@ class EntriesList extends StatelessWidget {
     );
   }
 
+  Widget _buildErrorState(BuildContext context, Exception e) {
+    print(e);
+    return Container(
+        alignment: Alignment.center,
+        child: Column(children: [
+          const Text(
+            'Entries failed to load. Tap to retry',
+          ),
+          ElevatedButton(
+              onPressed: () {
+                context.read<EntriesBloc>().add(LoadEntries());
+              },
+              child: const Text('Retry'))
+        ]));
+  }
+
   Widget _buildZeroState() {
     return Container(
         alignment: Alignment.center,
-        child: Text(
-          "No entries exist!",
+        child: const Text(
+          'No entries exist!',
         ));
   }
 }

--- a/flutter/lib/intro/view/sign_up_form/sign_up_form.dart
+++ b/flutter/lib/intro/view/sign_up_form/sign_up_form.dart
@@ -35,7 +35,7 @@ class SignUpFormState extends State<SignUpForm> {
         children: [
           TextFormField(
             autofocus: true,
-            decoration: const InputDecoration(labelText: 'First Name'),
+            decoration: const InputDecoration(labelText: 'First Name *'),
             controller: _firstNameController,
             keyboardType: TextInputType.name,
             validator: (value) {
@@ -47,7 +47,7 @@ class SignUpFormState extends State<SignUpForm> {
           ),
           SizedBox(height: 16),
           TextFormField(
-            decoration: const InputDecoration(labelText: 'Last Name'),
+            decoration: const InputDecoration(labelText: 'Last Name *'),
             controller: _lastNameController,
             keyboardType: TextInputType.name,
             validator: (value) {

--- a/flutter/test/entries/models/entry_test.dart
+++ b/flutter/test/entries/models/entry_test.dart
@@ -7,8 +7,18 @@ void main() {
       test('if two equal entries, return the same hashCode', () {
         final location = Location('city', 'country', LatLng(1, 2));
         final dateTime = DateTime.now();
-        final entry1 = Entry('id', 'title', 'body', dateTime, location);
-        final entry2 = Entry('id', 'title', 'body', dateTime, location);
+        final entry1 = Entry(
+            id: 'id',
+            title: 'title',
+            body: 'body',
+            dateTime: dateTime,
+            location: location);
+        final entry2 = Entry(
+            id: 'id',
+            title: 'title',
+            body: 'body',
+            dateTime: dateTime,
+            location: location);
         expect(entry1.hashCode, equals(entry2.hashCode));
       });
 
@@ -16,16 +26,36 @@ void main() {
           () {
         final location = Location('city', 'country', LatLng(1, 2));
         final dateTime = DateTime.now();
-        final entry1 = Entry('id1', 'title', 'body', dateTime, location);
-        final entry2 = Entry('id2', 'title', 'body', dateTime, location);
+        final entry1 = Entry(
+            id: 'id1',
+            title: 'title',
+            body: 'body',
+            dateTime: dateTime,
+            location: location);
+        final entry2 = Entry(
+            id: 'id2',
+            title: 'title',
+            body: 'body',
+            dateTime: dateTime,
+            location: location);
         expect(entry1.hashCode, isNot(equals(entry2.hashCode)));
       });
 
       test('if two entries with inverted values, return the same hashCode', () {
         final location = Location('city', 'country', LatLng(1, 2));
         final dateTime = DateTime.now();
-        final entry1 = Entry('id', 'title', 'body', dateTime, location);
-        final entry2 = Entry('title', 'id', 'body', dateTime, location);
+        final entry1 = Entry(
+            id: 'id',
+            title: 'title',
+            body: 'body',
+            dateTime: dateTime,
+            location: location);
+        final entry2 = Entry(
+            id: 'title',
+            title: 'id',
+            body: 'body',
+            dateTime: dateTime,
+            location: location);
         expect(entry1.hashCode, (equals(entry2.hashCode)));
       });
     });
@@ -34,8 +64,18 @@ void main() {
       test('if two equal entries, returns true', () {
         final location = Location('city', 'country', LatLng(1, 2));
         final dateTime = DateTime.now();
-        final entry1 = Entry('id', 'title', 'body', dateTime, location);
-        final entry2 = Entry('id', 'title', 'body', dateTime, location);
+        final entry1 = Entry(
+            id: 'id',
+            title: 'title',
+            body: 'body',
+            dateTime: dateTime,
+            location: location);
+        final entry2 = Entry(
+            id: 'id',
+            title: 'title',
+            body: 'body',
+            dateTime: dateTime,
+            location: location);
         expect(entry1 == entry2, isTrue);
         expect(entry2 == entry1, isTrue);
       });
@@ -43,8 +83,18 @@ void main() {
       test('if two entries with different values, return false', () {
         final location = Location('city', 'country', LatLng(1, 2));
         final dateTime = DateTime.now();
-        final entry1 = Entry('id1', 'title', 'body', dateTime, location);
-        final entry2 = Entry('id2', 'title', 'body', dateTime, location);
+        final entry1 = Entry(
+            id: 'id1',
+            title: 'title',
+            body: 'body',
+            dateTime: dateTime,
+            location: location);
+        final entry2 = Entry(
+            id: 'id2',
+            title: 'title',
+            body: 'body',
+            dateTime: dateTime,
+            location: location);
         expect(entry1 == entry2, isFalse);
         expect(entry2 == entry1, isFalse);
       });
@@ -52,8 +102,18 @@ void main() {
       test('if two entries with inverted values, return false', () {
         final location = Location('city', 'country', LatLng(1, 2));
         final dateTime = DateTime.now();
-        final entry1 = Entry('id', 'title', 'body', dateTime, location);
-        final entry2 = Entry('title', 'id', 'body', dateTime, location);
+        final entry1 = Entry(
+            id: 'id',
+            title: 'title',
+            body: 'body',
+            dateTime: dateTime,
+            location: location);
+        final entry2 = Entry(
+            id: 'title',
+            title: 'id',
+            body: 'body',
+            dateTime: dateTime,
+            location: location);
         expect(entry1 == entry2, isFalse);
         expect(entry2 == entry1, isFalse);
       });
@@ -63,7 +123,12 @@ void main() {
       test('returns string with all values', () {
         final location = Location('city', 'country', LatLng(1, 2));
         final dateTime = DateTime(2021, 5, 21, 6);
-        final entry = Entry('id', 'title', 'body', dateTime, location);
+        final entry = Entry(
+            id: 'id',
+            title: 'title',
+            body: 'body',
+            dateTime: dateTime,
+            location: location);
         final expectedString = 'Entry{id: id, title: title, body: body, '
             'dateTime: 2021-05-21 06:00:00.000, '
             'location: Location{city: city, country: country, '

--- a/flutter/test/entries/persistence/entry_dao_test.dart
+++ b/flutter/test/entries/persistence/entry_dao_test.dart
@@ -5,7 +5,12 @@ void main() {
   group('EntryDao', () {
     final location = Location('city', 'country', LatLng(1, 2));
     final dateTime = DateTime(2021, 5, 21, 6);
-    final entry = Entry('id', 'title', 'body', dateTime, location);
+    final entry = Entry(
+        id: 'id',
+        title: 'title',
+        body: 'body',
+        dateTime: dateTime,
+        location: location);
     final map = {
       'id': 'id',
       'title': 'title',


### PR DESCRIPTION
This PR contains work for the following items:
- [ ] Fixed the failing Entry and Entry DAO tests
- [ ] Added all required fields and data entry for the Entry creation form
- [ ] Hooked up the Entry creation form to write to database
- [ ] Added an error state that allows for database refetching
- [ ] Basic render support for Entry list items