### PR TITLE
Upgrade flutter_bloc

### DIFF
--- a/flutter/.gitignore
+++ b/flutter/.gitignore
@@ -18,7 +18,7 @@
 # The .vscode folder contains launch configuration and tasks you configure in
 # VS Code which you may wish to be included in version control, so this line
 # is commented out by default.
-#.vscode/
+.vscode/
 
 # Flutter/Dart/Pub related
 **/doc/api/

--- a/flutter/ios/Flutter/AppFrameworkInfo.plist
+++ b/flutter/ios/Flutter/AppFrameworkInfo.plist
@@ -21,6 +21,6 @@
   <key>CFBundleVersion</key>
   <string>1.0</string>
   <key>MinimumOSVersion</key>
-  <string>8.0</string>
+  <string>9.0</string>
 </dict>
 </plist>

--- a/flutter/ios/Flutter/Debug.xcconfig
+++ b/flutter/ios/Flutter/Debug.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"
 #include "Generated.xcconfig"

--- a/flutter/ios/Flutter/Release.xcconfig
+++ b/flutter/ios/Flutter/Release.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"
 #include "Generated.xcconfig"

--- a/flutter/ios/Podfile
+++ b/flutter/ios/Podfile
@@ -1,0 +1,41 @@
+# Uncomment this line to define a global platform for your project
+# platform :ios, '9.0'
+
+# CocoaPods analytics sends network stats synchronously affecting flutter build latency.
+ENV['COCOAPODS_DISABLE_STATS'] = 'true'
+
+project 'Runner', {
+  'Debug' => :debug,
+  'Profile' => :release,
+  'Release' => :release,
+}
+
+def flutter_root
+  generated_xcode_build_settings_path = File.expand_path(File.join('..', 'Flutter', 'Generated.xcconfig'), __FILE__)
+  unless File.exist?(generated_xcode_build_settings_path)
+    raise "#{generated_xcode_build_settings_path} must exist. If you're running pod install manually, make sure flutter pub get is executed first"
+  end
+
+  File.foreach(generated_xcode_build_settings_path) do |line|
+    matches = line.match(/FLUTTER_ROOT\=(.*)/)
+    return matches[1].strip if matches
+  end
+  raise "FLUTTER_ROOT not found in #{generated_xcode_build_settings_path}. Try deleting Generated.xcconfig, then run flutter pub get"
+end
+
+require File.expand_path(File.join('packages', 'flutter_tools', 'bin', 'podhelper'), flutter_root)
+
+flutter_ios_podfile_setup
+
+target 'Runner' do
+  use_frameworks!
+  use_modular_headers!
+
+  flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
+end
+
+post_install do |installer|
+  installer.pods_project.targets.each do |target|
+    flutter_additional_ios_build_settings(target)
+  end
+end

--- a/flutter/ios/Podfile.lock
+++ b/flutter/ios/Podfile.lock
@@ -1,0 +1,43 @@
+PODS:
+  - Flutter (1.0.0)
+  - FMDB (2.7.5):
+    - FMDB/standard (= 2.7.5)
+  - FMDB/standard (2.7.5)
+  - geolocator_apple (1.2.0):
+    - Flutter
+  - shared_preferences_ios (0.0.1):
+    - Flutter
+  - sqflite (0.0.2):
+    - Flutter
+    - FMDB (>= 2.7.5)
+
+DEPENDENCIES:
+  - Flutter (from `Flutter`)
+  - geolocator_apple (from `.symlinks/plugins/geolocator_apple/ios`)
+  - shared_preferences_ios (from `.symlinks/plugins/shared_preferences_ios/ios`)
+  - sqflite (from `.symlinks/plugins/sqflite/ios`)
+
+SPEC REPOS:
+  trunk:
+    - FMDB
+
+EXTERNAL SOURCES:
+  Flutter:
+    :path: Flutter
+  geolocator_apple:
+    :path: ".symlinks/plugins/geolocator_apple/ios"
+  shared_preferences_ios:
+    :path: ".symlinks/plugins/shared_preferences_ios/ios"
+  sqflite:
+    :path: ".symlinks/plugins/sqflite/ios"
+
+SPEC CHECKSUMS:
+  Flutter: 50d75fe2f02b26cc09d224853bb45737f8b3214a
+  FMDB: 2ce00b547f966261cd18927a3ddb07cb6f3db82a
+  geolocator_apple: b741765c55dc21950e3e106e8b3584e55cf81ce5
+  shared_preferences_ios: aef470a42dc4675a1cdd50e3158b42e3d1232b32
+  sqflite: 6d358c025f5b867b29ed92fc697fd34924e11904
+
+PODFILE CHECKSUM: aafe91acc616949ddb318b77800a7f51bffa2a4c
+
+COCOAPODS: 1.11.2

--- a/flutter/ios/Runner.xcodeproj/project.pbxproj
+++ b/flutter/ios/Runner.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		1498D2341E8E89220040F4C2 /* GeneratedPluginRegistrant.m in Sources */ = {isa = PBXBuildFile; fileRef = 1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */; };
 		3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */; };
+		61DC6F35B42142C3D4ED18DD /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BA95DF7123AB41A521109787 /* Pods_Runner.framework */; };
 		74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74858FAE1ED2DC5600515810 /* AppDelegate.swift */; };
 		97C146FC1CF9000F007C117D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FA1CF9000F007C117D /* Main.storyboard */; };
 		97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FD1CF9000F007C117D /* Assets.xcassets */; };
@@ -32,6 +33,7 @@
 		1498D2321E8E86230040F4C2 /* GeneratedPluginRegistrant.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GeneratedPluginRegistrant.h; sourceTree = "<group>"; };
 		1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GeneratedPluginRegistrant.m; sourceTree = "<group>"; };
 		3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = AppFrameworkInfo.plist; path = Flutter/AppFrameworkInfo.plist; sourceTree = "<group>"; };
+		42D2E6B916E9BEA3D3E354F0 /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
 		74858FAD1ED2DC5600515810 /* Runner-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Runner-Bridging-Header.h"; sourceTree = "<group>"; };
 		74858FAE1ED2DC5600515810 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Release.xcconfig; path = Flutter/Release.xcconfig; sourceTree = "<group>"; };
@@ -42,6 +44,9 @@
 		97C146FD1CF9000F007C117D /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		97C147001CF9000F007C117D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		97C147021CF9000F007C117D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		BA95DF7123AB41A521109787 /* Pods_Runner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		D9BF1FE76CC72C2DDF64E154 /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
+		F6E94A96B989344ECDBA252D /* Pods-Runner.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.profile.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -49,12 +54,21 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				61DC6F35B42142C3D4ED18DD /* Pods_Runner.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		7E7D0FE28F50BBC6583EC756 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				BA95DF7123AB41A521109787 /* Pods_Runner.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
 		9740EEB11CF90186004384FC /* Flutter */ = {
 			isa = PBXGroup;
 			children = (
@@ -72,6 +86,8 @@
 				9740EEB11CF90186004384FC /* Flutter */,
 				97C146F01CF9000F007C117D /* Runner */,
 				97C146EF1CF9000F007C117D /* Products */,
+				DB345D72738243D09BB5AF09 /* Pods */,
+				7E7D0FE28F50BBC6583EC756 /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -98,6 +114,17 @@
 			path = Runner;
 			sourceTree = "<group>";
 		};
+		DB345D72738243D09BB5AF09 /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				D9BF1FE76CC72C2DDF64E154 /* Pods-Runner.debug.xcconfig */,
+				42D2E6B916E9BEA3D3E354F0 /* Pods-Runner.release.xcconfig */,
+				F6E94A96B989344ECDBA252D /* Pods-Runner.profile.xcconfig */,
+			);
+			name = Pods;
+			path = Pods;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -105,12 +132,14 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 97C147051CF9000F007C117D /* Build configuration list for PBXNativeTarget "Runner" */;
 			buildPhases = (
+				1E31AB98C83A4ED76B248B0E /* [CP] Check Pods Manifest.lock */,
 				9740EEB61CF901F6004384FC /* Run Script */,
 				97C146EA1CF9000F007C117D /* Sources */,
 				97C146EB1CF9000F007C117D /* Frameworks */,
 				97C146EC1CF9000F007C117D /* Resources */,
 				9705A1C41CF9048500538489 /* Embed Frameworks */,
 				3B06AD1E1E4923F5004D2608 /* Thin Binary */,
+				1B5799275657547798BE77CA /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -169,6 +198,45 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		1B5799275657547798BE77CA /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		1E31AB98C83A4ED76B248B0E /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-Runner-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
 		3B06AD1E1E4923F5004D2608 /* Thin Binary */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;

--- a/flutter/ios/Runner.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/flutter/ios/Runner.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -2,6 +2,6 @@
 <Workspace
    version = "1.0">
    <FileRef
-      location = "group:Runner.xcodeproj">
+      location = "self:">
    </FileRef>
 </Workspace>

--- a/flutter/ios/Runner.xcworkspace/contents.xcworkspacedata
+++ b/flutter/ios/Runner.xcworkspace/contents.xcworkspacedata
@@ -4,4 +4,7 @@
    <FileRef
       location = "group:Runner.xcodeproj">
    </FileRef>
+   <FileRef
+      location = "group:Pods/Pods.xcodeproj">
+   </FileRef>
 </Workspace>

--- a/flutter/lib/authentication/blocs/user_bloc.dart
+++ b/flutter/lib/authentication/blocs/user_bloc.dart
@@ -9,30 +9,23 @@ part 'user_state.dart';
 class UserBloc extends Bloc<UserEvent, UserState> {
   final UserRepository userRepository;
 
-  UserBloc({required this.userRepository}) : super(UserLoading());
-
-  @override
-  Stream<UserState> mapEventToState(UserEvent event) async* {
-    if (event is LoadUser) {
-      yield* _mapLoadUserToState();
-    } else if (event is RemoveUser) {
-      yield* _mapRemoveUserToState();
-    } else if (event is SetUser) {
-      yield* _mapSetUserToState(event);
-    }
+  UserBloc({required this.userRepository}) : super(UserLoading()) {
+    on<LoadUser>(_onLoadUser);
+    on<RemoveUser>(_onRemoveUser);
+    on<SetUser>(_onSetUser);
   }
 
-  Stream<UserState> _mapLoadUserToState() async* {
+  void _onLoadUser(LoadUser event, Emitter<UserState> emit) async {
     try {
       final user = await userRepository.getUser();
-      yield UserLoaded(user);
+      emit(UserLoaded(user));
     } catch (e) {
-      yield UserNotLoaded(e as Exception);
+      emit(UserNotLoaded(e as Exception));
     }
   }
 
-  Stream<UserState> _mapRemoveUserToState() async* {
-    yield UserLoaded(null);
+  void _onRemoveUser(RemoveUser event, Emitter<UserState> emit) async {
+    emit(UserLoaded(null));
 
     if (state is UserLoaded) {
       // Only perform remove on loaded state if a user exists
@@ -44,8 +37,8 @@ class UserBloc extends Bloc<UserEvent, UserState> {
     }
   }
 
-  Stream<UserState> _mapSetUserToState(SetUser event) async* {
-    yield UserLoaded(event.user);
+  void _onSetUser(SetUser event, Emitter<UserState> emit) async {
+    emit(UserLoaded(event.user));
     await userRepository.setUser(event.user);
   }
 }

--- a/flutter/lib/authentication/blocs/user_state.dart
+++ b/flutter/lib/authentication/blocs/user_state.dart
@@ -12,7 +12,7 @@ class UserLoading extends UserState {}
 class UserLoaded extends UserState {
   final User? user;
 
-  const UserLoaded([this.user = null]);
+  const UserLoaded([this.user]);
 
   @override
   List<Object> get props => [user ?? true];

--- a/flutter/lib/entries/blocs/entries_bloc.dart
+++ b/flutter/lib/entries/blocs/entries_bloc.dart
@@ -1,5 +1,3 @@
-import 'dart:async';
-
 import 'package:bloc/bloc.dart';
 import 'package:equatable/equatable.dart';
 

--- a/flutter/lib/entries/blocs/entries_bloc.dart
+++ b/flutter/lib/entries/blocs/entries_bloc.dart
@@ -12,63 +12,55 @@ part 'entries_state.dart';
 class EntriesBloc extends Bloc<EntriesEvent, EntriesState> {
   final EntryRepository entryRepository;
 
-  EntriesBloc({required this.entryRepository}) : super(EntriesLoading());
-
-  @override
-  Stream<EntriesState> mapEventToState(EntriesEvent event) async* {
-    if (event is LoadEntries) {
-      yield* _mapLoadEntriesToState();
-    } else if (event is AddEntry) {
-      yield* _mapAddEntryToState(event);
-    } else if (event is UpdateEntry) {
-      yield* _mapUpdateEntryToState(event);
-    } else if (event is DeleteEntry) {
-      yield* _mapDeleteEntryToState(event);
-    }
+  EntriesBloc({required this.entryRepository}) : super(EntriesLoading()) {
+    on<LoadEntries>(_onLoadEntries);
+    on<AddEntry>(_onAddEntry);
+    on<UpdateEntry>(_onUpdateEntry);
+    on<DeleteEntry>(_onDeleteEntry);
   }
 
-  Stream<EntriesState> _mapLoadEntriesToState() async* {
+  void _onLoadEntries(LoadEntries event, Emitter<EntriesState> emit) async {
     try {
       final entries = await entryRepository.getEntries();
-      yield EntriesLoaded(entries);
+      emit(EntriesLoaded(entries));
     } catch (e) {
       if (e is Exception) {
-        yield EntriesNotLoaded(e);
+        emit(EntriesNotLoaded(e));
       } else if (e is TypeError) {
-        yield EntriesNotLoaded(Exception(e.toString()));
+        emit(EntriesNotLoaded(Exception(e.toString())));
       } else {
-        yield EntriesNotLoaded(
-            Exception('Something went wrong while loading entries'));
+        emit(EntriesNotLoaded(
+            Exception('Something went wrong while loading entries')));
       }
     }
   }
 
-  Stream<EntriesState> _mapAddEntryToState(AddEntry event) async* {
+  void _onAddEntry(AddEntry event, Emitter<EntriesState> emit) async {
     if (state is EntriesLoaded) {
       final updatedEntries = List<Entry>.from((state as EntriesLoaded).entries)
         ..add(event.entry);
-      yield EntriesLoaded(updatedEntries);
+      emit(EntriesLoaded(updatedEntries));
       await entryRepository.insert(event.entry);
     }
   }
 
-  Stream<EntriesState> _mapUpdateEntryToState(UpdateEntry event) async* {
+  void _onUpdateEntry(UpdateEntry event, Emitter<EntriesState> emit) async {
     if (state is EntriesLoaded) {
       final updatedEntries = (state as EntriesLoaded).entries.map((entry) {
         return entry.id == event.updatedEntry.id ? event.updatedEntry : entry;
       }).toList();
-      yield EntriesLoaded(updatedEntries);
+      emit(EntriesLoaded(updatedEntries));
       await entryRepository.update(event.updatedEntry);
     }
   }
 
-  Stream<EntriesState> _mapDeleteEntryToState(DeleteEntry event) async* {
+  void _onDeleteEntry(DeleteEntry event, Emitter<EntriesState> emit) async {
     if (state is EntriesLoaded) {
       final updatedEntries = (state as EntriesLoaded)
           .entries
           .where((entry) => entry.id != event.entry.id)
           .toList();
-      yield EntriesLoaded(updatedEntries);
+      emit(EntriesLoaded(updatedEntries));
       await entryRepository.delete(event.entry.id);
     }
   }

--- a/flutter/lib/entries/models/entry.dart
+++ b/flutter/lib/entries/models/entry.dart
@@ -1,5 +1,4 @@
 import 'package:equatable/equatable.dart';
-import 'package:journey/entries/entries.dart';
 import 'package:journey/models/uuid.dart';
 import 'package:meta/meta.dart';
 

--- a/flutter/lib/entries/view/add_entry_form/add_entry_form.dart
+++ b/flutter/lib/entries/view/add_entry_form/add_entry_form.dart
@@ -63,7 +63,7 @@ class AddEntryFormState extends State<AddEntryForm> {
 
   // Store date and location in state internally
   DateTime _date = DateTime.now();
-  Location? _location = null;
+  Location? _location;
 
   // Default to disabled since typing in one field validates the rest
   AutovalidateMode _autovalidateMode = AutovalidateMode.disabled;

--- a/flutter/lib/router/delegate.dart
+++ b/flutter/lib/router/delegate.dart
@@ -30,7 +30,7 @@ class AppRouterDelegate extends RouterDelegate<AppPath>
   GlobalKey<NavigatorState> get navigatorKey => _navigatorKey;
 
   AppRouterDelegate(this._userRepository)
-      : _navigatorKey = GlobalKey<NavigatorState>() {}
+      : _navigatorKey = GlobalKey<NavigatorState>();
 
   @override
   Widget build(BuildContext context) {

--- a/flutter/pubspec.lock
+++ b/flutter/pubspec.lock
@@ -7,21 +7,21 @@ packages:
       name: _fe_analyzer_shared
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "21.0.0"
+    version: "30.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.5.0"
+    version: "2.7.0"
   args:
     dependency: transitive
     description:
       name: args
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.3.0"
   async:
     dependency: transitive
     description:
@@ -35,7 +35,7 @@ packages:
       name: bloc
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "7.2.1"
+    version: "8.0.1"
   boolean_selector:
     dependency: transitive
     description:
@@ -63,7 +63,7 @@ packages:
       name: cli_util
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.0"
+    version: "0.3.5"
   clock:
     dependency: transitive
     description:
@@ -84,14 +84,14 @@ packages:
       name: convert
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.0"
+    version: "3.0.1"
   coverage:
     dependency: transitive
     description:
       name: coverage
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.2"
+    version: "1.0.3"
   crypto:
     dependency: transitive
     description:
@@ -105,7 +105,7 @@ packages:
       name: cupertino_icons
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.3"
+    version: "1.0.4"
   english_words:
     dependency: "direct main"
     description:
@@ -119,7 +119,7 @@ packages:
       name: equatable
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.0.3"
   fake_async:
     dependency: transitive
     description:
@@ -140,7 +140,7 @@ packages:
       name: file
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.1.0"
+    version: "6.1.2"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -152,7 +152,7 @@ packages:
       name: flutter_bloc
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "7.3.0"
+    version: "8.0.0"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -176,7 +176,7 @@ packages:
       name: geolocator
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "7.7.0"
+    version: "7.7.1"
   geolocator_android:
     dependency: transitive
     description:
@@ -211,7 +211,7 @@ packages:
       name: glob
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.1"
+    version: "2.0.2"
   http_multi_server:
     dependency: transitive
     description:
@@ -239,7 +239,7 @@ packages:
       name: io
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.0"
+    version: "1.0.3"
   js:
     dependency: transitive
     description:
@@ -253,7 +253,7 @@ packages:
       name: logging
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.1"
+    version: "1.0.2"
   matcher:
     dependency: transitive
     description:
@@ -274,7 +274,7 @@ packages:
       name: mime
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.0"
+    version: "1.0.1"
   nested:
     dependency: transitive
     description:
@@ -295,7 +295,7 @@ packages:
       name: package_config
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.0.2"
   path:
     dependency: transitive
     description:
@@ -309,7 +309,7 @@ packages:
       name: path_provider_linux
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.2"
   path_provider_platform_interface:
     dependency: transitive
     description:
@@ -323,14 +323,14 @@ packages:
       name: path_provider_windows
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.3"
+    version: "2.0.4"
   pedantic:
     dependency: transitive
     description:
       name: pedantic
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.11.0"
+    version: "1.11.1"
   platform:
     dependency: transitive
     description:
@@ -344,7 +344,7 @@ packages:
       name: plugin_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.1"
+    version: "2.0.2"
   pool:
     dependency: transitive
     description:
@@ -358,7 +358,7 @@ packages:
       name: process
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.2.3"
+    version: "4.2.4"
   provider:
     dependency: transitive
     description:
@@ -372,11 +372,25 @@ packages:
       name: pub_semver
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.1.0"
   shared_preferences:
     dependency: "direct main"
     description:
       name: shared_preferences
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.9"
+  shared_preferences_android:
+    dependency: transitive
+    description:
+      name: shared_preferences_android
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.8"
+  shared_preferences_ios:
+    dependency: transitive
+    description:
+      name: shared_preferences_ios
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.8"
@@ -386,7 +400,7 @@ packages:
       name: shared_preferences_linux
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.2"
+    version: "2.0.3"
   shared_preferences_macos:
     dependency: transitive
     description:
@@ -414,14 +428,14 @@ packages:
       name: shared_preferences_windows
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.2"
+    version: "2.0.3"
   shelf:
     dependency: transitive
     description:
       name: shelf
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.4"
+    version: "1.2.0"
   shelf_packages_handler:
     dependency: transitive
     description:
@@ -435,7 +449,7 @@ packages:
       name: shelf_static
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.0"
+    version: "1.1.0"
   shelf_web_socket:
     dependency: transitive
     description:
@@ -475,14 +489,14 @@ packages:
       name: sqflite
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0+3"
+    version: "2.0.0+4"
   sqflite_common:
     dependency: transitive
     description:
       name: sqflite_common
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0+2"
+    version: "2.0.1+1"
   stack_trace:
     dependency: transitive
     description:
@@ -559,14 +573,14 @@ packages:
       name: vm_service
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.2.0"
+    version: "7.5.0"
   watcher:
     dependency: transitive
     description:
       name: watcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.0"
+    version: "1.0.1"
   web_socket_channel:
     dependency: transitive
     description:
@@ -587,7 +601,7 @@ packages:
       name: win32
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.2.9"
+    version: "2.3.0"
   xdg_directories:
     dependency: transitive
     description:

--- a/flutter/pubspec.yaml
+++ b/flutter/pubspec.yaml
@@ -29,7 +29,7 @@ dependencies:
     cupertino_icons: ^1.0.3
     english_words: ^4.0.0
     equatable: ^2.0.0
-    flutter_bloc: ^7.3.0
+    flutter_bloc: ^8.0.0
     geolocator: ^7.7.0
     intl: ^0.17.0
     shared_preferences: ^2.0.8


### PR DESCRIPTION
In version 8.0 of `flutter_bloc`, the `mapEventToState` boilerplate has been replaced with easy `on` handlers that can be set via Bloc constructors. 

See the migration docs for more info:
https://bloclibrary.dev/#/migration